### PR TITLE
Added functionality to include cortex metadata in the output file

### DIFF
--- a/vb_toolbox/app.py
+++ b/vb_toolbox/app.py
@@ -94,6 +94,25 @@ def main():
 
     n_cpus = args.jobs[0]
     nib_surf, vertices, faces = io.open_gifti_surf(args.surface[0])
+
+    # Get the text contents from the file
+    surf_text = open(args.surface[0], 'r', encoding='latin-1')
+
+    hemi = None
+
+    # Check whether the file is left or right cortex
+    for line in surf_text:
+        if 'CortexLeft' in line:
+            hemi = 'CortexLeft'
+            break
+        elif 'CortexRight' in line:
+            hemi = 'CortexRight'
+            break
+
+    # Add the cortex information to the beginning of the meta data
+    if hemi:
+        nib_surf.meta.data.insert(0, nibabel.gifti.GiftiNVPairs('AnatomicalStructurePrimary', hemi))
+
     nib = nibabel.load(args.data[0])
     if len(nib.darrays) > 1:
         cifti = np.array([n.data for n in nib.darrays]).transpose()

--- a/vb_toolbox/io.py
+++ b/vb_toolbox/io.py
@@ -64,5 +64,9 @@ def save_gifti(og_img, data, filename):
     """
     # For some reason, wc_view demands float32
     data_array = nibabel.gifti.gifti.GiftiDataArray(np.array(data, dtype=np.float32))
-    new_nib = nibabel.gifti.gifti.GiftiImage(darrays=[data_array])
+
+    # Create a meta object containing the cortex information
+    new_meta = nibabel.gifti.gifti.GiftiMetaData(og_img.meta.data[0])
+    new_nib = nibabel.gifti.gifti.GiftiImage(darrays=[data_array], meta=new_meta)
+
     nibabel.save(new_nib, filename)

--- a/vb_toolbox/numerics.py
+++ b/vb_toolbox/numerics.py
@@ -26,7 +26,7 @@ def force_symmetric(M):
     -------
     M_sym: Symmetric version of M
     """
-    # One diag extracs the diagonal into an array, two
+    # One diag extracts the diagonal into an array, two
     # diags turns the array into a diagonal matrix.
     diag_M = np.diag(np.diag(M))
     triu_M = np.triu(M, 1)
@@ -132,7 +132,7 @@ def spectral_reorder(B, method = 'geig'):
         warnings.warn("""
         The value 1 is being added to your similarity matrix to ensure positivity.
         This may cause issues with interpretation. Consider inputing a positive matrix""",
-        warning.UserWarning)
+        warnings.UserWarning)
         C = B + 1
     else:
         C = B
@@ -149,7 +149,7 @@ def spectral_reorder(B, method = 'geig'):
     C = triuC + triuC.transpose() # Reconstruct a symmetric weighted adjacency matrix eliminating possible small errors in off-diagonal elements
     D =  np.diag(np.sum(C, axis=-1)) # Compute the Degree matrix
 
-    Q = D - C; #Compute un-normalised Laplacian
+    Q = D - C; # Compute un-normalised Laplacian
 
     method = method.lower()
 
@@ -161,7 +161,6 @@ def spectral_reorder(B, method = 'geig'):
         # eigenvectors = -eigenvectors
 
     elif method == 'sym':
-
         # Method using the eigen decomposition of the Symmetric Normalized
         # Laplacian. Note that results should be the same as 'geig'
         T = np.sqrt(D)
@@ -172,8 +171,8 @@ def spectral_reorder(B, method = 'geig'):
         eigenvectors = spl.solve(T, eigenvectors) # renormalize
 
     elif method == 'rw':
-      # Method using eigen decomposition of Random Walk Normalised Laplacian
-      # This method has not been rigorously tested yet
+        # Method using eigen decomposition of Random Walk Normalised Laplacian
+        # This method has not been rigorously tested yet
 
         L = spl.solve(D, Q)
 

--- a/vb_toolbox/vb_index.py
+++ b/vb_toolbox/vb_index.py
@@ -55,7 +55,7 @@ def vb_index_internal_loop(i0, iN, surf_faces, data, norm, print_progress=False)
     loc_result = np.zeros(diff)
 
     for idx in range(diff):
-        #Calculate the real index
+        # Calculate the real index
         i = idx + i0
 
         # Get neighborhood and its data
@@ -101,7 +101,7 @@ def vb_index(surf_vertices, surf_faces, n_cpus, data, norm, cort_index, output_n
        surf_faces: (M, 3) numpy array
            Faces of the mesh. Used to find the neighborhood of a given vertice
        n_cpus: integer
-               How many CPUS to run the calcualation
+               How many CPUS to run the calculation
        data: (M, N) numpy array
            Data to use the to calculate the VB index. M must math the number of vertices in the mesh
        norm: string
@@ -230,7 +230,7 @@ def vb_cluster(surf_vertices, surf_faces, n_cpus, data, cluster_index, norm, out
        surf_faces: (M, 3) numpy array
            Faces of the mesh. Used to find the neighborhood of a given vertice
        n_cpus: integer
-               How many CPUS to run the calcualation
+               How many CPUS to run the calculation
        data: (M, N) numpy array
            Data to use the to calculate the VB index. M must math the number of vertices in the mesh
        cluster_index: (M) numpy array


### PR DESCRIPTION
At the moment, the files created by the VB Index do not include the necessary metadata to define which hemisphere they contain, this causes minor problems in programs like wb_view.

To fix this, I have added a small change, which takes the cortex information from the surface file, and adds it to the metadata of the output file. This makes it easier to load the files into the wb_view, without needing to manually specify the hemisphere.