### PR TITLE
Update vb_index.py

### DIFF
--- a/vb_toolbox/vb_index.py
+++ b/vb_toolbox/vb_index.py
@@ -404,6 +404,7 @@ def vb_hybrid_internal_loop(i0, iN, surf_vertices, surf_faces, affine, data, nor
                 neighborhood = get_neighborhood(data,surf_vertices,surf_faces,i,affine,k=k)
             to_keep = np.where(np.std(neighborhood,axis=1)>1e-10)
             neighborhood = np.squeeze(neighborhood[to_keep,:])
+	    neighborhood = np.atleast_2d(neighborhood)
             loc_neigh[idx] = len(neighborhood)
 
             if len(neighborhood) == 0:


### PR DESCRIPTION
Added np.atleast_2d after 'squeezing out' any 'empty' voxels from the neighborhood. This way, if the squeezing removes all voxels but one, its time series is converted from a 1D array to a 2D array and the size of the neighbourhood is stored as 1, rather than the length of the time series. 