### PR TITLE
Working With Different Eigenvalues

### DIFF
--- a/vb_toolbox/app.py
+++ b/vb_toolbox/app.py
@@ -55,6 +55,11 @@ def create_parser():
     parser = argparse.ArgumentParser(description='Calculate the Vogt-Bailey index of a dataset. For more information, refer to https://github.com/VBIndex/py_vb_toolbox.',
                                      epilog=authors + " |n " + references + " |n " + copyright,
                                      formatter_class=MultilineFormatter)
+
+
+    parser.add_argument('-e', '--eigenvalue-index', metavar='INDEX', type=int, nargs=1, default=1,
+                        help="""Index of the eigenvalue to use. Default is the second smallest eigenvalue (index 1).""")
+
     parser.add_argument('-j', '--jobs', metavar='N', type=int, nargs=1,
                         default=[multiprocessing.cpu_count()], help="""Maximum
                         number of jobs to be used. If absent, one job per CPU
@@ -149,6 +154,10 @@ def main():
     args = parser.parse_args()
 
     n_cpus = args.jobs[0]
+    
+    eigenvalue_index = args.eigenvalue_index    
+    
+
     if not args.volume:
         nib_surf, vertices, faces = vb_index.open_gifti_surf(args.surface[0])
 
@@ -247,14 +256,14 @@ def main():
             else:
                 size = args.size
             try:
-                vb_index.compute_temporal_analysis_volumetric(window_size=window_size, steps=steps, size=size, path=args.path, n_cpus=n_cpus, nib=nib, affine=affine, header=header, norm=L_norm, cort_index=cort_index, brain_mask=brain_mask, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], output_name=args.output[0], reho=args.reho)
+                vb_index.compute_temporal_analysis_volumetric(window_size=window_size, steps=steps, size=size, path=args.path, n_cpus=n_cpus, nib=nib, affine=affine, header=header, norm=L_norm, cort_index=cort_index, brain_mask=brain_mask, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], output_name=args.output[0], reho=args.reho, eigenvalue_index=eigenvalue_index)
                 sys.exit(1)
             except Exception as error:
                 sys.stderr.write(str(error))
                 sys.exit(2)
                 quit()
         try:
-                vb_index.compute_vb_metrics(internal_loop_func="vb_vol", n_cpus=n_cpus, data=data, affine=affine, header=header, norm=L_norm, cort_index=cort_index, brain_mask=brain_mask, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], output_name=args.output[0] + "." + L_norm, reho=args.reho)
+                vb_index.compute_vb_metrics(internal_loop_func="vb_vol", n_cpus=n_cpus, data=data, affine=affine, header=header, norm=L_norm, cort_index=cort_index, brain_mask=brain_mask, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], eigenvalue_index = eigenvalue_index, output_name=args.output[0] + "." + L_norm, reho=args.reho)
             
         except Exception as error:
             sys.stderr.write(str(error))
@@ -284,7 +293,7 @@ def main():
                 else:
                     size = args.size
                 try:
-                    vb_index.compute_temporal_analysis_hybrid(window_size=window_size, steps=steps, size=size, path=args.path, surf_vertices=vertices, surf_faces=faces, affine=affine, n_cpus=n_cpus, nib=nib, norm=L_norm, cort_index=cort_index, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], output_name=args.output[0], nib_surf=nib_surf, k=3, reho=args.reho, debug=args.debug)
+                    vb_index.compute_temporal_analysis_hybrid(window_size=window_size, steps=steps, size=size, path=args.path, surf_vertices=vertices, surf_faces=faces, affine=affine, n_cpus=n_cpus, nib=nib, norm=L_norm, cort_index=cort_index, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], output_name=args.output[0], nib_surf=nib_surf, k=3, reho=args.reho, debug=args.debug, eigenvalue_index=eigenvalue_index)
                     sys.exit(1)
                 except Exception as error:
                     sys.stderr.write(str(error))


### PR DESCRIPTION
This pull request introduces the ability to select which eigenvalue to work with in app.py, with a default of second eigenvalue. This change gives flexibility to the application while maintaining the existing functionality of the vb_index code. Also it helps users  to have control over which eigenvalue they work with, enhancing the capacity of the application of VB index.

Chnages that are made in the code:


APP.PY

parser.add_argument('-e', '--eigenvalue-index', metavar='INDEX', type=int, nargs=1, default=1, help="""Index of the eigenvalue to use. Default is the second smallest eigenvalue (index 1).""")

eigenvalue_index = args.eigenvalue_index

vb_index.compute_vb_metrics(internal_loop_func="vb_vol", n_cpus=n_cpus, data=data, affine=affine, header=header, norm=L_norm, cort_index=cort_index, brain_mask=brain_mask, residual_tolerance=args.tol[0], max_num_iter=args.maxiter[0], eigenvalue_index=eigenvalue_index, output_name=args.output[0] + "." + L_norm, reho=args.reho)

VB_INDEX.PY

def compute_vb_metrics(internal_loop_func, n_cpus, data, norm, residual_tolerance, max_num_iter, eigenvalue_index, header=None, brain_mask=None, surf_vertices=None, surf_faces=None, output_name=None, nib_surf=None, k=None, cluster_index=None, cort_index=None, affine=None, reho=False, full_brain=False, debug=False):

results = run_multiprocessing(pool, internal_loop_func, n_items, dn, surf_vertices, surf_faces, data, norm, residual_tolerance, max_num_iter, eigenvalue_index, cluster_index, cort_index, affine, k, reho, full_brain, brain_mask, debug)

def run_multiprocessing(pool, internal_loop_func, n_items, dn, surf_vertices, surf_faces, data, norm, residual_tolerance, max_num_iter, eigenvalue_index, cluster_index, cort_index, affine, k, reho, full_brain, brain_mask, debug):

threads = np.append(threads, (pool.apply_async(vb_vol_internal_loop, (i0, iN, data, norm, brain_mask, residual_tolerance, max_num_iter, eigenvalue_index, reho, debug), error_callback=pool_callback)))

def vb_vol_internal_loop(i0, iN, data, norm, brain_mask, residual_tolerance, max_num_iter, eigenvalue_index, reho, debug=False):

compute_vol(neighborhood, i, idx, loc_result, affinity, vox_coords, residual_tolerance, max_num_iter, eigenvalue_index, norm)

def compute_vol(neighborhood, i, idx, loc_result, affinity, vox_coords, residual_tolerance, max_num_iter, eigenvalue_index, norm):

_, _, eigenvalue, _ = spectral_reorder(False, affinity, residual_tolerance, max_num_iter, eigenvalue_index, norm)

def get_fiedler_eigenpair(eigenvalue_index, method, full_brain, Q, D=None, is_symmetric=True, tol='def_tol', maxiter=50):

def spectral_reorder(full_brain, B, residual_tolerance, max_num_iter, eigenvalue_index, method='unnorm'):

vbi_value, eigenvector = get_fiedler_eigenpair(eigenvalue_index, method, full_brain, Q, tol=residual_tolerance, maxiter=max_num_iter)
