### PR TITLE
Add requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,7 @@ numpy
 scipy
 nibabel
 multiprocess
-textwrap
-sys
-warnings
-traceback
-glob
-os
-signal
-shutil
+textwrap3
 ```
 
 The preferred way to install is through pip. It is as easy as

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+argparse
+numpy
+scipy
+nibabel
+multiprocess
+textwrap3


### PR DESCRIPTION
The requirements file can then be used to install dependencies:

```
pip install -r requirements.txt
```

This commit also removes built-in libraries from requirements, since they do not have to be installed explicitly.

Closes: https://github.com/VBIndex/py_vb_toolbox/issues/66